### PR TITLE
Make fetching and checking out remote branches more reliable

### DIFF
--- a/cmd/mv.go
+++ b/cmd/mv.go
@@ -21,8 +21,7 @@ func init() {
 			values := map[string]string{"branch1": branch1, "branch2": branch2}
 
 			sh("{{git}} push {{origin}} {{branch1}}:refs/heads/{{branch2}}", values)
-			sh("{{git}} fetch {{origin}}", values)
-			sh("{{git}} branch --track {{branch2}} {{origin}}/{{branch2}}", values)
+			sh("{{git}} fetch {{origin}} {{branch}}:{{branch}}", values)
 			sh("{{git}} checkout {{branch2}}", values)
 			sh("{{git}} branch -d {{branch1}}", values)
 			sh("{{git}} push {{origin}} :refs/heads/{{branch1}}", values)

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -14,8 +14,7 @@ func init() {
 			values := map[string]string{"branch": args[0]}
 
 			sh("{{git}} push {{origin}} {{current_branch}}:refs/heads/{{branch}}", values)
-			sh("{{git}} fetch {{origin}}", values)
-			sh("{{git}} branch --track {{branch}} {{origin}}:{{branch}}", values)
+			sh("{{git}} fetch {{origin}} {{branch}}:{{branch}}", values)
 			sh("{{git}} checkout {{branch}}", values)
 		},
 	})


### PR DESCRIPTION
Today, both `grb new` and `grb mv` fail on repositories that have not been fully cloned.

You can reproduce this yourself by running:
```
$ git clone -b master --depth 1 git@github.com:jinzhu/grb.git
$ grb new test
```

The output of the second command ends up being:
```
git push origin master:refs/heads/test
Total 0 (delta 0), reused 0 (delta 0)
To github.com:jinzhu/grb.git
 * [new branch]      master -> test
git fetch origin
git branch --track test origin/test
error: the requested upstream branch 'origin/test' does not exist
hint: 
hint: If you are planning on basing your work on an upstream
hint: branch that already exists at the remote, you may need to
hint: run "git fetch" to retrieve it.
hint: 
hint: If you are planning to push out a new local branch that
hint: will track its remote counterpart, you may want to use
hint: "git push -u" to set the upstream config as you push.
git checkout test
error: pathspec 'test' did not match any file(s) known to git.
```

(Note that I ran the above on my own fork, rather than on this repo)

This failure happens because fetching origin doesn't bring remote branches down onto the local repo. This PR avoids this failure by replacing the less-reliable `fetch origin` and `branch --track` commands with the all-encompassing `fetch origin branch:branch`. Let me know what you think!