### PR TITLE
Update "go install" syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A tool to simplify working with git remote branches.
 ## Install
 
 ```sh
-go install github.com/jinzhu/grb
+go install github.com/jinzhu/grb@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Installing this on a new laptop, got this error:
```
go install github.com/jinzhu/grb
go install: version is required when current directory is not in a module
	Try 'go install github.com/jinzhu/grb@latest' to install the latest version
```